### PR TITLE
Fix SOCK_DGRAM for unprivileged users

### DIFF
--- a/src/pinger.rs
+++ b/src/pinger.rs
@@ -30,28 +30,28 @@ pub fn run(args: Args, hosts_in: Vec<(String, IpAddr)>) {
   let has_v4 = hosts.iter().any(|h| !h.is_ipv6);
   let has_v6 = hosts.iter().any(|h| h.is_ipv6);
 
-  let (fd4, kind4) = if has_v4 {
-    let (fd, kind) = open_raw_socket(false).unwrap_or_else(|e| {
+  let (fd4, kind4, dgram_id4) = if has_v4 {
+    let (fd, kind, kid) = open_raw_socket(false).unwrap_or_else(|e| {
       eprintln!("fping: {}", e);
       std::process::exit(3);
     });
-    (Some(fd), kind)
+    (Some(fd), kind, kid)
   } else {
-    (None, SocketKind::Raw)
+    (None, SocketKind::Raw, None)
   };
 
-  let (fd6, kind6) = if has_v6 {
-    let (fd, kind) = open_raw_socket(true).unwrap_or_else(|e| {
+  let (fd6, kind6, dgram_id6) = if has_v6 {
+    let (fd, kind, kid) = open_raw_socket(true).unwrap_or_else(|e| {
       eprintln!("fping: {}", e);
       std::process::exit(3);
     });
-    (Some(fd), kind)
+    (Some(fd), kind, kid)
   } else {
-    (None, SocketKind::Raw)
+    (None, SocketKind::Raw, None)
   };
 
-  // ICMP-ID = PID
-  let my_id = (std::process::id() & 0xFFFF) as u16;
+  let pid_id = (std::process::id() & 0xFFFF) as u16;
+  let my_id = dgram_id4.or(dgram_id6).unwrap_or(pid_id);
 
   let interval = Duration::from_millis(args.interval);
   let period   = Duration::from_millis(args.period);
@@ -88,7 +88,8 @@ pub fn run(args: Args, hosts_in: Vec<(String, IpAddr)>) {
       seq_counter = seq_counter.wrapping_add(1);
 
       let is_ipv6  = hosts[idx].is_ipv6;
-      let pkt = build_icmp_packet(my_id, seq, args.size, is_ipv6);
+      let kind = if is_ipv6 { kind6 } else { kind4 };
+      let pkt = build_icmp_packet(my_id, seq, args.size, is_ipv6, kind);
 
       let sent = match hosts[idx].addr {
         IpAddr::V4(ref a) => fd4.map(|fd| send_ping_v4(fd, a, &pkt)).unwrap_or(false),

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -11,11 +11,11 @@ use crate::constants::{
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum SocketKind {
-    Raw,
-    Dgram,
+  Raw,
+  Dgram,
 }
 
-pub fn open_raw_socket(is_ipv6: bool) -> Result<(RawFd, SocketKind), String> {
+pub fn open_raw_socket(is_ipv6: bool) -> Result<(RawFd, SocketKind, Option<u16>), String> {
   let (domain, proto) = if is_ipv6 {
     (AF_INET6, IPPROTO_ICMPV6)
   } else {
@@ -25,19 +25,59 @@ pub fn open_raw_socket(is_ipv6: bool) -> Result<(RawFd, SocketKind), String> {
   let fd = unsafe { libc::socket(domain, SOCK_RAW, proto) };
   if fd >= 0 {
     set_nonblocking(fd);
-    return Ok((fd, SocketKind::Raw));
+    return Ok((fd, SocketKind::Raw, None));
   }
 
   let fd = unsafe { libc::socket(domain, SOCK_DGRAM, proto) };
   if fd >= 0 {
     set_nonblocking(fd);
-    return Ok((fd, SocketKind::Dgram));
+    let assigned_id = dgram_bind_and_get_id(fd, is_ipv6);
+    return Ok((fd, SocketKind::Dgram, assigned_id));
   }
 
   Err(format!(
-    "Unable to open ICMP{}-socket. Run as root or with CAP_NET_RAW.",
+    "Unable to open ICMP{} socket (no root and SOCK_DGRAM denied).\n\
+    Fix with one of:\n\
+    \x20 sudo setcap cap_net_raw+ep ./fping\n\
+    \x20 sudo sysctl -w net.ipv4.ping_group_range=\"0 2147483647\"",
     if is_ipv6 { "v6" } else { "" }
   ))
+}
+
+fn dgram_bind_and_get_id(fd: RawFd, is_ipv6: bool) -> Option<u16> {
+  unsafe {
+    if is_ipv6 {
+      let mut sa: libc::sockaddr_in6 = std::mem::zeroed();
+      sa.sin6_family = AF_INET6 as libc::sa_family_t;
+      let r = libc::bind(
+        fd,
+        &sa as *const _ as *const libc::sockaddr,
+        std::mem::size_of::<libc::sockaddr_in6>() as socklen_t,
+      );
+      if r < 0 { return None; }
+
+      let mut sa2: libc::sockaddr_in6 = std::mem::zeroed();
+      let mut len = std::mem::size_of::<libc::sockaddr_in6>() as socklen_t;
+      let r = libc::getsockname(fd, &mut sa2 as *mut _ as *mut libc::sockaddr, &mut len);
+      if r < 0 || sa2.sin6_port == 0 { return None; }
+      Some(u16::from_be(sa2.sin6_port))
+    } else {
+      let mut sa: libc::sockaddr_in = std::mem::zeroed();
+      sa.sin_family = AF_INET as libc::sa_family_t;
+      let r = libc::bind(
+        fd,
+        &sa as *const _ as *const libc::sockaddr,
+        std::mem::size_of::<libc::sockaddr_in>() as socklen_t,
+      );
+      if r < 0 { return None; }
+
+      let mut sa2: libc::sockaddr_in = std::mem::zeroed();
+      let mut len = std::mem::size_of::<libc::sockaddr_in>() as socklen_t;
+      let r = libc::getsockname(fd, &mut sa2 as *mut _ as *mut libc::sockaddr, &mut len);
+      if r < 0 || sa2.sin_port == 0 { return None; }
+      Some(u16::from_be(sa2.sin_port))
+    }
+  }
 }
 
 fn set_nonblocking(fd: RawFd) {
@@ -47,7 +87,7 @@ fn set_nonblocking(fd: RawFd) {
   }
 }
 
-pub fn build_icmp_packet(id: u16, seq: u16, data_size: usize, is_ipv6: bool) -> Vec<u8> {
+pub fn build_icmp_packet(id: u16, seq: u16, data_size: usize, is_ipv6: bool, kind: SocketKind) -> Vec<u8> {
   let total = ICMP_HEADER_LEN + data_size;
   let mut pkt = vec![0u8; total];
 
@@ -133,9 +173,10 @@ pub struct ReceivedPing {
 }
 
 pub fn recv_ping(fd: RawFd, buf: &mut [u8], is_ipv6: bool, kind: SocketKind) -> Option<ReceivedPing> {
+  let mut src: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+  let mut src_len = std::mem::size_of::<libc::sockaddr_storage>() as socklen_t;
+
   let n = unsafe {
-    let mut src: libc::sockaddr_storage = std::mem::zeroed();
-    let mut src_len = std::mem::size_of::<libc::sockaddr_storage>() as socklen_t;
     recvfrom(
       fd,
       buf.as_mut_ptr() as *mut c_void,
@@ -153,14 +194,14 @@ pub fn recv_ping(fd: RawFd, buf: &mut [u8], is_ipv6: bool, kind: SocketKind) -> 
   let raw_len = n as usize;
   let data = &buf[..raw_len];
 
-  let icmp = if is_ipv6 || kind == SocketKind::Dgram {
-    if data.len() < 8 { return None; }
-    data
-  } else {
+  let icmp = if !is_ipv6 && kind == SocketKind::Raw {
     if data.len() < 20 + 8 { return None; }
     let ihl = ((data[0] & 0x0F) as usize) * 4;
     if data.len() < ihl + 8 { return None; }
     &data[ihl..]
+  } else {
+    if data.len() < 8 { return None; }
+    data
   };
 
   let icmp_type = icmp[0];
@@ -169,8 +210,10 @@ pub fn recv_ping(fd: RawFd, buf: &mut [u8], is_ipv6: bool, kind: SocketKind) -> 
     return None;
   }
 
+  let id = u16::from_be_bytes([icmp[4], icmp[5]]);
+
   Some(ReceivedPing {
-    id:  u16::from_be_bytes([icmp[4], icmp[5]]),
+    id,
     seq: u16::from_be_bytes([icmp[6], icmp[7]]),
     is_ipv6,
     raw_len,


### PR DESCRIPTION
Remove the artificial nulling in socket.rs
The ID should always be included and the kernel overwrites it anyway for SOCK_DGRAM