### PR TITLE
Fix dns resolve fallback if ipv6 not found

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -19,7 +19,8 @@ pub fn resolve(name: &str, only_ipv4: bool, only_ipv6: bool) -> Option<IpAddr> {
 
   if only_ipv6 {
     addrs.iter().find(|a| a.is_ipv6()).copied()
-      .or_else(|| addrs.first().copied())
+  } else if only_ipv4 {
+    addrs.iter().find(|a| a.is_ipv4()).copied() 
   } else {
     addrs.iter().find(|a| a.is_ipv4()).copied()
       .or_else(|| addrs.first().copied())


### PR DESCRIPTION
The `or_else` fallback was incorrect in both branches it completely ignored the set filter. Now, `None` is returned if the desired address type is not present.