### PR TITLE
Update to README and fix warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # fping-rust
 
+[<img alt="github" src="https://img.shields.io/badge/github-gsnw/fping-rust?style=for-the-badge&logo=github" height="20">](https://github.com/gsnw/fping-rust)
+[![Rust CI](https://github.com/gsnw/fping-rust/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/gsnw/fping-rust/actions/workflows/rust-ci.yml)
+
 fping-rust is an attempt to translate the fping program from https://github.com/schweikert/fping into Rust.
 
 This version is licensed under the GPL
 
 ## Original
 
-fping is a program to send ICMP echo probes to network hosts, similar to ping,
+Original fping is a program to send ICMP echo probes to network hosts, similar to ping,
 but much better performing when pinging multiple hosts. fping has a long long
 story: Roland Schemers did publish a first version of it in 1992 and it has
 established itself since then as a standard tool.
@@ -15,6 +18,56 @@ established itself since then as a standard tool.
 
 ```
 cargo build
+cargo install --path=/usr/local
+```
+
+Make fping either setuid, or, if under Linux
+
+```
+sudo setcap cap_net_raw,cap_net_admin+ep fping`
+```
+
+If you can't run fping as root or can't use the cap_net_raw capability, you can also run fping in unprivileged mode. This works on MacOS and also on Linux, provided that your GID is included in the range defined in `/proc/sys/net/ipv4/ping_group_range`. This is particularly useful for running fping-rust in rootless / unprivileged containers.
+
+```
+echo "net.ipv4.ping_group_range = 0 2147483647" >> /etc/sysctl.d/local.conf
+```
+
+## Usage
+
+```
+Fast ping to multiple hosts
+
+Usage: fping [OPTIONS] [TARGETS]...
+
+Arguments:
+  [TARGETS]...  Target hosts
+
+Options:
+  -c, --count <N>          Count mode: send N pings to each target
+  -C, --vcount <N>         Same as -c but verbose output (all RTTs)
+  -l, --loop               Loop mode: send pings forever
+  -i, --interval <MSEC>    Interval between packets in ms (default: 10) [default: 10]
+  -p, --period <MSEC>      Per-host interval in ms (default: 1000) [default: 1000]
+  -t, --timeout <MSEC>     Timeout in ms (default: 500) [default: 500]
+  -r, --retry <RETRY>      Number of retries (default: 3) [default: 3]
+  -B, --backoff <BACKOFF>  Exponential backoff factor (default: 1.5) [default: 1.5]
+  -b, --size <BYTES>       Ping data size in bytes (default: 56) [default: 56]
+  -f, --file <FILE>        Read hosts from file (- = stdin)
+  -a, --alive              Show only alive hosts
+  -u, --unreach            Show only unreachable hosts
+  -q, --quiet              Quiet: don't show per-ping results
+  -s, --stats              Print final stats
+  -e, --elapsed            Show elapsed time on received packets
+  -A, --addr               Show targets by address
+  -D, --timestamp          Timestamp before each line
+  -J, --json               JSON output (requires -c, -C or -l)
+  -4, --ipv4               Use IPv4 only
+  -6, --ipv6               Use IPv6 only
+      --report-all-rtts    Show all individual RTTs
+  -x, --reachable <N>      Minimum number of reachable hosts to be considered success
+  -h, --help               Print help
+  -V, --version            Print version
 ```
 
 ## Test

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,6 @@
 /* cargo rust */
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-pub const PROGRAM: &str = env!("CARGO_PKG_NAME");
+pub const _PROGRAM: &str = env!("CARGO_PKG_NAME");
 
 /* ICMP Typ */
 pub const ICMP_ECHO_REQUEST: u8 = 8;
@@ -10,26 +10,26 @@ pub const ICMP6_ECHO_REPLY: u8 = 129;
 pub const ICMP_HEADER_LEN: usize = 8;
 
 /* Default values */
-pub const DEFAULT_INTERVAL_MS: u64 = 10;
-pub const DEFAULT_PERIOD_MS: u64 = 1000;
-pub const DEFAULT_TIMEOUT_MS: u64 = 500;
-pub const DEFAULT_RETRY: u32 = 3;
-pub const DEFAULT_BACKOFF: f64 = 1.5;
-pub const DEFAULT_PING_DATA_SIZE: usize = 56;
+pub const _DEFAULT_INTERVAL_MS: u64 = 10;
+pub const _DEFAULT_PERIOD_MS: u64 = 1000;
+pub const _DEFAULT_TIMEOUT_MS: u64 = 500;
+pub const _DEFAULT_RETRY: u32 = 3;
+pub const _DEFAULT_BACKOFF: f64 = 1.5;
+pub const _DEFAULT_PING_DATA_SIZE: usize = 56;
 
-pub const MIN_BACKOFF: f64 = 1.0;
-pub const MAX_BACKOFF: f64 = 5.0;
+pub const _MIN_BACKOFF: f64 = 1.0;
+pub const _MAX_BACKOFF: f64 = 5.0;
 
-pub const MAX_GENERATE: usize = 131_072;
-pub const MAX_TARGET_NAME: usize = 255;
+pub const _MAX_GENERATE: usize = 131_072;
+pub const _MAX_TARGET_NAME: usize = 255;
 
 /* Response flags */
-pub const RESP_WAITING: i64 = -1;
-pub const RESP_UNUSED: i64 = -2;
-pub const RESP_TIMEOUT: i64 = -4;
+pub const _RESP_WAITING: i64 = -1;
+pub const _RESP_UNUSED: i64 = -2;
+pub const _RESP_TIMEOUT: i64 = -4;
 
 /* ICMP-Typ-Name */
-pub const ICMP_TYPE_STR: &[&str] = &[
+pub const _ICMP_TYPE_STR: &[&str] = &[
   "ICMP Echo Reply",          // 0
   "",
   "",
@@ -51,7 +51,7 @@ pub const ICMP_TYPE_STR: &[&str] = &[
   "ICMP Mask Reply",          // 18
 ];
 
-pub const ICMP_UNREACH_STR: &[&str] = &[
+pub const _ICMP_UNREACH_STR: &[&str] = &[
   "ICMP Network Unreachable",
   "ICMP Host Unreachable",
   "ICMP Protocol Unreachable",

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -87,7 +87,7 @@ fn set_nonblocking(fd: RawFd) {
   }
 }
 
-pub fn build_icmp_packet(id: u16, seq: u16, data_size: usize, is_ipv6: bool, kind: SocketKind) -> Vec<u8> {
+pub fn build_icmp_packet(id: u16, seq: u16, data_size: usize, is_ipv6: bool, _kind: SocketKind) -> Vec<u8> {
   let total = ICMP_HEADER_LEN + data_size;
   let mut pkt = vec![0u8; total];
 
@@ -168,7 +168,6 @@ pub fn send_ping_v6(fd: RawFd, addr: &Ipv6Addr, pkt: &[u8]) -> bool {
 pub struct ReceivedPing {
   pub id: u16,
   pub seq: u16,
-  pub is_ipv6: bool,
   pub raw_len: usize,
 }
 
@@ -215,7 +214,6 @@ pub fn recv_ping(fd: RawFd, buf: &mut [u8], is_ipv6: bool, kind: SocketKind) -> 
   Some(ReceivedPing {
     id,
     seq: u16::from_be_bytes([icmp[6], icmp[7]]),
-    is_ipv6,
     raw_len,
   })
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,6 @@ use std::time::{Duration, Instant};
 
 #[derive(Debug)]
 pub struct HostEntry {
-  pub name: String,
   pub display: String,
   pub addr: IpAddr,
   pub is_ipv6: bool,
@@ -27,7 +26,6 @@ impl HostEntry {
   pub fn new(name: String, addr: IpAddr, is_ipv6: bool, count: u32) -> Self {
     let display = name.clone();
     HostEntry {
-      name,
       display,
       addr,
       is_ipv6,
@@ -76,14 +74,4 @@ pub struct PendingPing {
   pub host_index: usize,
   pub ping_index: u32,
   pub sent_at: Instant,
-}
-
-#[derive(Default)]
-pub struct GlobalStats {
-  pub num_alive: usize,
-  pub num_unreachable: usize,
-  pub num_pingsent: u32,
-  pub num_pingreceived: u32,
-  pub num_othericmprcvd: u32,
-  pub num_timeout: u32,
 }

--- a/tests/dns_tests.rs
+++ b/tests/dns_tests.rs
@@ -46,7 +46,6 @@ fn resolve_localhost_ipv4_only() {
 }
 
 #[test]
-#[test]
 fn resolve_localhost_ipv6_only() {
     let result = resolve("localhost", false, true);
     match result {


### PR DESCRIPTION
Fix the following warnings

```
warning: unused variable: `kind`
  --> src/socket.rs:90:78
   |
90 | pub fn build_icmp_packet(id: u16, seq: u16, data_size: usize, is_ipv6: bool, kind: SocketKind) -> Vec<u8> {
   |                                                                              ^^^^ help: if this is intentional, prefix it with an underscore: `_kind`
   |
   = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

warning: `fping-rust` (lib) generated 1 warning (run `cargo fix --lib -p fping-rust` to apply 1 suggestion)
warning: constant `PROGRAM` is never used
 --> src/constants.rs:3:11
  |
3 | pub const PROGRAM: &str = env!("CARGO_PKG_NAME");
  |           ^^^^^^^
  |
  = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: constant `DEFAULT_INTERVAL_MS` is never used
  --> src/constants.rs:13:11
   |
13 | pub const DEFAULT_INTERVAL_MS: u64 = 10;
   |           ^^^^^^^^^^^^^^^^^^^

warning: constant `DEFAULT_PERIOD_MS` is never used
  --> src/constants.rs:14:11
   |
14 | pub const DEFAULT_PERIOD_MS: u64 = 1000;
   |           ^^^^^^^^^^^^^^^^^

warning: constant `DEFAULT_TIMEOUT_MS` is never used
  --> src/constants.rs:15:11
   |
15 | pub const DEFAULT_TIMEOUT_MS: u64 = 500;
   |           ^^^^^^^^^^^^^^^^^^

warning: constant `DEFAULT_RETRY` is never used
  --> src/constants.rs:16:11
   |
16 | pub const DEFAULT_RETRY: u32 = 3;
   |           ^^^^^^^^^^^^^

warning: constant `DEFAULT_BACKOFF` is never used
  --> src/constants.rs:17:11
   |
17 | pub const DEFAULT_BACKOFF: f64 = 1.5;
   |           ^^^^^^^^^^^^^^^

warning: constant `DEFAULT_PING_DATA_SIZE` is never used
  --> src/constants.rs:18:11
   |
18 | pub const DEFAULT_PING_DATA_SIZE: usize = 56;
   |           ^^^^^^^^^^^^^^^^^^^^^^

warning: constant `MIN_BACKOFF` is never used
  --> src/constants.rs:20:11
   |
20 | pub const MIN_BACKOFF: f64 = 1.0;
   |           ^^^^^^^^^^^

warning: constant `MAX_BACKOFF` is never used
  --> src/constants.rs:21:11
   |
21 | pub const MAX_BACKOFF: f64 = 5.0;
   |           ^^^^^^^^^^^

warning: constant `MAX_GENERATE` is never used
  --> src/constants.rs:23:11
   |
23 | pub const MAX_GENERATE: usize = 131_072;
   |           ^^^^^^^^^^^^

warning: constant `MAX_TARGET_NAME` is never used
  --> src/constants.rs:24:11
   |
24 | pub const MAX_TARGET_NAME: usize = 255;
   |           ^^^^^^^^^^^^^^^

warning: constant `RESP_WAITING` is never used
  --> src/constants.rs:27:11
   |
27 | pub const RESP_WAITING: i64 = -1;
   |           ^^^^^^^^^^^^

warning: constant `RESP_UNUSED` is never used
  --> src/constants.rs:28:11
   |
28 | pub const RESP_UNUSED: i64 = -2;
   |           ^^^^^^^^^^^

warning: constant `RESP_TIMEOUT` is never used
  --> src/constants.rs:29:11
   |
29 | pub const RESP_TIMEOUT: i64 = -4;
   |           ^^^^^^^^^^^^

warning: constant `ICMP_TYPE_STR` is never used
  --> src/constants.rs:32:11
   |
32 | pub const ICMP_TYPE_STR: &[&str] = &[
   |           ^^^^^^^^^^^^^

warning: constant `ICMP_UNREACH_STR` is never used
  --> src/constants.rs:54:11
   |
54 | pub const ICMP_UNREACH_STR: &[&str] = &[
   |           ^^^^^^^^^^^^^^^^

warning: field `is_ipv6` is never read
   --> src/socket.rs:171:7
    |
168 | pub struct ReceivedPing {
    |            ------------ field in this struct
...
171 |   pub is_ipv6: bool,
    |       ^^^^^^^

warning: field `name` is never read
 --> src/types.rs:6:7
  |
5 | pub struct HostEntry {
  |            --------- field in this struct
6 |   pub name: String,
  |       ^^^^
  |
  = note: `HostEntry` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis

warning: struct `GlobalStats` is never constructed
  --> src/types.rs:82:12
   |
82 | pub struct GlobalStats {
   |            ^^^^^^^^^^^

warning: `fping-rust` (bin "fping") generated 20 warnings (1 duplicate)
```