### PR TITLE
Update github release pipline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,55 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
-  publish:
-    name: Publish crate
+  release:
+    name: Build and Publish
     runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cargo package check
+        run: cargo package
+
+      - name: Verify publish (dry-run)
+        run: cargo publish --dry-run
+      
+      - name: Check version on crates.io
+        run: |
+          CRATE_NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].name')
+          LOCAL_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+
+          echo "Crate: $CRATE_NAME"
+          echo "Version: $LOCAL_VERSION"
+
+          if curl -s https://crates.io/api/v1/crates/$CRATE_NAME | jq -e ".crate.max_version == \"$LOCAL_VERSION\"" ; then
+            echo "Version already published!"
+            exit 1
+          fi
+
+      - name: Publish to crates.io
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  build-binaries:
+    name: Build binaries
+    runs-on: ${{ matrix.os }}
+    needs: release
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - name: Checkout repository
@@ -17,13 +62,47 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build
+      - name: Build release binary
         run: cargo build --release
 
-      - name: Run tests
-        run: cargo test --release
+      - name: Package binary (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir dist
+          cp target/release/* dist/ || true
+          tar -czf release-${{ runner.os }}.tar.gz dist
 
-      - name: Publish to crates.io
-        run: cargo publish --locked
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ runner.os }}
+          path: |
+            *.tar.gz
+            *.zip
+
+  github-release:
+    name: Create GitHub Release
+    needs: build-binaries
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      
+      - name: Generate changelog
+        id: changelog
+        run: |
+          git log $(git describe --tags --abbrev=0 HEAD^)..HEAD --pretty=format:"- %s" > CHANGELOG.md
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: CHANGELOG.md
+          files: artifacts/**/*


### PR DESCRIPTION
* cargo package + cargo publish --dry-run
* Version check against crates.io
* Publication on crates.io
* Automatic GitHub release
* Binary builds (Linux / macOS)
* Upload of binaries to the release
* Automatic changelog