### PR TITLE
Fix IPv4 sendto double byte-swap on little-endian hosts

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -133,7 +133,7 @@ pub fn send_ping_v4(fd: RawFd, addr: &Ipv4Addr, pkt: &[u8]) -> bool {
   unsafe {
     let mut sa: libc::sockaddr_in = std::mem::zeroed();
     sa.sin_family = AF_INET as libc::sa_family_t;
-    sa.sin_addr.s_addr = u32::from_ne_bytes(addr.octets()).to_be();
+    sa.sin_addr.s_addr = u32::from_ne_bytes(addr.octets());
 
     let n = sendto(
       fd,


### PR DESCRIPTION
## Summary

Fixes #9

Remove the spurious `.to_be()` call in `send_ping_v4` that caused a double byte-swap of the destination IPv4 address, sending ICMP packets to the wrong host on little-endian platforms.

## Changes

- **`src/socket.rs`**: Remove `.to_be()` from the `s_addr` assignment in `send_ping_v4`. `u32::from_ne_bytes(addr.octets())` already produces the correct network-order value by preserving the in-memory byte layout of the octets, making the additional swap incorrect on little-endian targets.

## Test plan

- [x] Verify `send_ping_v4` resolves and pings the correct address on a little-endian host (x86_64 / aarch64)
- [x] Verify no regression on big-endian targets (`.to_be()` was a no-op there, so removing it is safe)
- [x] Confirm IPv6 pings are unaffected (uses `[u8; 16]` byte array, no integer conversion involved)