### PR TITLE
fix: icmp checksum broken on little-endian systems

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -117,11 +117,11 @@ fn icmp_checksum(data: &[u8]) -> u16 {
   let mut sum: u32 = 0;
   let mut i = 0;
   while i + 1 < data.len() {
-    sum += u16::from_be_bytes([data[i], data[i + 1]]) as u32;
+    sum += u16::from_ne_bytes([data[i], data[i + 1]]) as u32;
     i += 2;
   }
   if i < data.len() {
-    sum += (data[i] as u32) << 8;
+    sum += data[i] as u32;
   }
   while sum >> 16 != 0 {
     sum = (sum & 0xFFFF) + (sum >> 16);


### PR DESCRIPTION
The current implementation of icmp_checksum is prone to errors related to endianness (byte order).

**Problem**: `u16::from_be_bytes` is used to add two bytes to form a `u32`. However, the standard algorithm (RFC 1071) operates on 16-bit words in the host's native byte order.

**Consequence**: On little-endian systems (such as almost all modern PCs), the calculated checksum could be incorrect, causing the recipient to discard the packet.