### PR TITLE
fix: record RTTs in loop/default mode for correct -s statistics

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -52,8 +52,13 @@ impl HostEntry {
     self.total_time += rtt;
     self.max_reply = Some(self.max_reply.map_or(rtt, |m| m.max(rtt)));
     self.min_reply = Some(self.min_reply.map_or(rtt, |m| m.min(rtt)));
-    if let Some(slot) = self.resp_times.get_mut(ping_index as usize) {
-      *slot = Some(rtt);
+    let idx = ping_index as usize;
+    if idx < self.resp_times.len() {
+      // count-mode: pre-allocated slot exists, write in place
+      self.resp_times[idx] = Some(rtt);
+    } else {
+      // loop/default-mode: resp_times is empty or shorter than ping_index, append dynamically so -s statistics are never empty
+      self.resp_times.push(Some(rtt));
     }
   }
 


### PR DESCRIPTION
In loop and default mode, `HostEntry::new` initializes `resp_times` as
an empty Vec (count == 0). The previous `record_reply` implementation
used `get_mut(ping_index)`, which silently returned None on an empty
Vec, causing all RTTs to be discarded without error.

As a result, the `all_rtts` aggregation in `pinger.rs` produced an
empty collection in loop/default mode, making min/avg/max all report
None when `-s` was used despite replies having been received.

Fix: distinguish the two cases in `record_reply`:
- count-mode: pre-allocated slot exists, write in place via index
- loop/default-mode: append RTTs dynamically via push()

No changes required in pinger.rs; the existing flat_map/filter_map
read path handles both a pre-allocated and a dynamically grown Vec
correctly.