### PR TITLE
fix: remove unreachable negative-ms branch in sprint_tm

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -4,9 +4,7 @@ use crate::types::HostEntry;
 
 pub fn sprint_tm(d: Duration) -> String {
   let ms = d.as_secs_f64() * 1000.0;
-  if ms < 0.0 {
-    format!("{:.2}", ms)
-  } else if ms < 1.0 {
+  if ms < 1.0 {
     format!("{:.3}", ms)
   } else if ms < 10.0 {
     format!("{:.2}", ms)


### PR DESCRIPTION
`Duration::as_secs_f64()` is guaranteed to be `>= 0.0` because Duration is
an unsigned type in Rust. The first branch in `sprint_tm` that handled
`ms < 0.0` was therefore dead code that could never be reached at runtime.