### PR TITLE
Add ncurses TUI quit/reset hotkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 fping-rust 0.2.0 (new)
 ======================
+- Add ncurses TUI quit/reset hotkeys (#21, @gsnw-sebast)
+  - fix: Keep ncurses TUI open after finishing pings
+  - fix: Move ncurses TUI status info to footer and fix refresh rate
+- ci: Creating a Makefile for a simple build (#20, @gsnw-sebast)
 - Add ncurses TUI mode for real-time host monitoring (#19, @gsnw-sebast)
 - New option --oiface for outgoing interface and source ip flag (#18, @gsnw-sebast)
 

--- a/src/pinger.rs
+++ b/src/pinger.rs
@@ -133,7 +133,7 @@ pub fn run(args: Args, hosts_in: Vec<(String, IpAddr)>) {
   loop {
     let now = Instant::now();
 
-    if args.tui && now.duration_since(last_tui_update).as_millis() >= 100 {
+    if args.tui && now.duration_since(last_tui_update).as_millis() >= 200 {
       match crate::tui::update(&hosts, start) {
         crate::tui::TuiAction::Quit => break,
         crate::tui::TuiAction::Reset => {

--- a/src/pinger.rs
+++ b/src/pinger.rs
@@ -13,6 +13,7 @@ use crate::socket::{bind_source_v4, bind_source_v6, build_icmp_packet, open_raw_
 use crate::types::{HostEntry, PendingPing};
 
 pub fn run(args: Args, hosts_in: Vec<(String, IpAddr)>) {
+  let hosts_backup = hosts_in.clone();
   let count = args.effective_count();
   let loop_mode = args.r#loop;
   let verbose_count = args.is_verbose_count();
@@ -120,7 +121,7 @@ pub fn run(args: Args, hosts_in: Vec<(String, IpAddr)>) {
   let mut seq_counter: u32 = 0;
   let mut recv_buf = vec![0u8; 4096];
 
-  let start = Instant::now();
+  let mut start = Instant::now();
   let max_len = max_host_len(&hosts);
 
   let mut last_tui_update = Instant::now();
@@ -133,9 +134,28 @@ pub fn run(args: Args, hosts_in: Vec<(String, IpAddr)>) {
     let now = Instant::now();
 
     if args.tui && now.duration_since(last_tui_update).as_millis() >= 100 {
-      if !crate::tui::update(&hosts, start) {
-        // Exit the loop when ‘q’ or ESC is pressed
-        break;
+      match crate::tui::update(&hosts, start) {
+        crate::tui::TuiAction::Quit => break,
+        crate::tui::TuiAction::Reset => {
+          seqmap.clear();
+          start = Instant::now();
+          hosts = hosts_backup
+            .iter()
+            .cloned()
+            .map(|(name, addr)| {
+              let is_ipv6 = addr.is_ipv6();
+              let display = if args.addr { addr.to_string() } else { name.clone() };
+              let mut h = HostEntry::new(name, addr, is_ipv6, count.unwrap_or(0));
+              h.display = display;
+              h
+            })
+            .collect();
+          for (i, h) in hosts.iter_mut().enumerate() {
+            h.next_send = Instant::now() + interval * i as u32;
+            h.retries_left = args.retry;
+          }
+        }
+        crate::tui::TuiAction::Continue => {}
       }
       last_tui_update = now;
     }

--- a/src/pinger.rs
+++ b/src/pinger.rs
@@ -160,7 +160,7 @@ pub fn run(args: Args, hosts_in: Vec<(String, IpAddr)>) {
       last_tui_update = now;
     }
 
-    if hosts.iter().all(|h| h.done) && seqmap.is_empty() {
+    if !args.tui && hosts.iter().all(|h| h.done) && seqmap.is_empty() {
       break;
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2,55 +2,67 @@ use ncurses::*;
 use std::time::Instant;
 use crate::types::HostEntry;
 
+pub enum TuiAction {
+  Continue,
+  Quit,
+  Reset,
+}
+
 pub fn init() {
-    initscr();
-    cbreak();
-    noecho();
-    timeout(0); // non-blocking getch()
-    curs_set(CURSOR_VISIBILITY::CURSOR_INVISIBLE);
+  initscr();
+  cbreak();
+  noecho();
+  timeout(0); // non-blocking getch()
+  curs_set(CURSOR_VISIBILITY::CURSOR_INVISIBLE);
 }
 
 pub fn cleanup() {
-    endwin();
+  endwin();
 }
 
-pub fn update(hosts: &[HostEntry], start: Instant) -> bool {
-    // Process user input (press q or ESC to exit)
-    let ch = getch();
-    if ch == 'q' as i32 || ch == 27 {
-        return false;
+pub fn update(hosts: &[HostEntry], start: Instant) -> TuiAction {
+  // Process user input (press q or ESC to exit)
+  let ch = getch();
+  if ch == 'q' as i32 || ch == 27 {
+    return TuiAction::Quit;
+  } else if ch == 'r' as i32 || ch == 'R' as i32 {
+    return TuiAction::Reset;
+  }
+
+  clear();
+  let elapsed = start.elapsed().as_secs_f64();
+
+  mvprintw(0, 0, "==========================================================================================");
+  mvprintw(1, 0, &format!(" fping-rs TUI | Hosts: {} | Elapsed: {:.1}s", hosts.len(), elapsed));
+  mvprintw(2, 0, " Controls: [q] Quit / Exit TUI  |  [r] Reset Statistics");
+  mvprintw(3, 0, "==========================================================================================");
+
+  mvprintw(5, 0, &format!("{:<20} | {:>6} | {:>6} | {:>6} | {:>8} | {:>8} | {:>8} | {:>8}",
+    "Host", "Sent", "Recv", "Loss%", "Min", "Avg", "Max", "Last"));
+  mvprintw(6, 0, &"-".repeat(90));
+
+  let mut row = 7;
+  for h in hosts {
+    let loss = h.loss_pct();
+
+    let min_s = h.min_reply.map(|d| format!("{:.1}ms", d.as_secs_f64() * 1000.0)).unwrap_or_else(|| "-".into());
+    let avg_s = h.avg_reply().map(|d| format!("{:.1}ms", d.as_secs_f64() * 1000.0)).unwrap_or_else(|| "-".into());
+    let max_s = h.max_reply.map(|d| format!("{:.1}ms", d.as_secs_f64() * 1000.0)).unwrap_or_else(|| "-".into());
+
+    let last_val = h.resp_times.iter().rev().find_map(|&r| r);
+    let last_s = last_val.map(|d| format!("{:.1}ms", d.as_secs_f64() * 1000.0)).unwrap_or_else(|| "-".into());
+
+    let mut display = h.display.clone();
+    if display.len() > 20 {
+      display.truncate(17);
+      display.push_str("...");
     }
 
-    clear();
-    let elapsed = start.elapsed().as_secs_f64();
-    mvprintw(0, 0, &format!("fping-rs TUI - Elapsed: {:.1}s (Press 'q' or ESC to quit)\n", elapsed));
+    mvprintw(row, 0, &format!("{:<20} | {:>6} | {:>6} | {:>5}% | {:>8} | {:>8} | {:>8} | {:>8}",
+      display, h.num_sent, h.num_recv, loss, min_s, avg_s, max_s, last_s));
+    row += 1;
+  }
 
-    mvprintw(2, 0, &format!("{:<20} | {:>6} | {:>6} | {:>6} | {:>8} | {:>8} | {:>8} | {:>8}",
-        "Host", "Sent", "Recv", "Loss%", "Min", "Avg", "Max", "Last"));
-    mvprintw(3, 0, &"-".repeat(90));
-
-    let mut row = 4;
-    for h in hosts {
-        let loss = h.loss_pct();
-
-        let min_s = h.min_reply.map(|d| format!("{:.1}ms", d.as_secs_f64() * 1000.0)).unwrap_or_else(|| "-".into());
-        let avg_s = h.avg_reply().map(|d| format!("{:.1}ms", d.as_secs_f64() * 1000.0)).unwrap_or_else(|| "-".into());
-        let max_s = h.max_reply.map(|d| format!("{:.1}ms", d.as_secs_f64() * 1000.0)).unwrap_or_else(|| "-".into());
-
-        let last_val = h.resp_times.iter().rev().find_map(|&r| r);
-        let last_s = last_val.map(|d| format!("{:.1}ms", d.as_secs_f64() * 1000.0)).unwrap_or_else(|| "-".into());
-
-        let mut display = h.display.clone();
-        if display.len() > 20 {
-            display.truncate(17);
-            display.push_str("...");
-        }
-
-        mvprintw(row, 0, &format!("{:<20} | {:>6} | {:>6} | {:>5}% | {:>8} | {:>8} | {:>8} | {:>8}",
-            display, h.num_sent, h.num_recv, loss, min_s, avg_s, max_s, last_s));
-        row += 1;
-    }
-
-    refresh();
-    true
+  refresh();
+  TuiAction::Continue
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,6 +1,7 @@
 use ncurses::*;
 use std::time::Instant;
 use crate::types::HostEntry;
+use chrono::Local;
 
 pub enum TuiAction {
   Continue,
@@ -62,6 +63,9 @@ pub fn update(hosts: &[HostEntry], start: Instant) -> TuiAction {
       display, h.num_sent, h.num_recv, loss, min_s, avg_s, max_s, last_s));
     row += 1;
   }
+
+  mvprintw(row + 1, 0, "==========================================================================================");
+  mvprintw(row + 2, 0, &format!(" Updated: {} | Interval: 200ms | Hosts: {}/{} visible", Local::now().format("%H:%M:%S"), hosts.len(), hosts.len()));
 
   refresh();
   TuiAction::Continue


### PR DESCRIPTION
This pull request makes the following change to the `--tui` parameter

- Add ncurses TUI quit/reset hotkeys
- fix: Keep ncurses TUI open after finishing pings
- fix: Move ncurses TUI status info to footer and fix refresh rate
  - Change TUI refresh interval to 200ms in pinger.rs
  - Relocate status information from the header to a footer below the host list in tui.rs
  - Add timestamp to footer using the chrono crate